### PR TITLE
Feature/optimize

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -32,7 +32,7 @@ type GeoConfig struct {
 func ReadGeometryFile(path string) GeoConfig {
 	content, err := os.ReadFile(path)
 	if err == nil {
-		fmt.Println("Reading geometry config from JSON file...")
+		fmt.Println("Reading geometry config from JSON file: ", path)
 
 		var config GeoConfig
 

--- a/influx.go
+++ b/influx.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
@@ -12,19 +11,19 @@ import (
 	write "github.com/influxdata/influxdb-client-go/v2/api/write"
 )
 
-func IoChannelToTileId(ioChannel int) int{
-	return (ioChannel - 1)/4 + 1
+func IoChannelToTileId(ioChannel int) int {
+	return (ioChannel-1)/4 + 1
 }
 
 func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time, timeDiff float64) {
 
-	// fmt.Println("\t", time.Now(), " : start writing to influx")
+	fmt.Println("\t", time.Now(), " : start writing to influx")
 
-	makePoint := func (name string) *write.Point {
+	makePoint := func(name string) *write.Point {
 		return influxdb2.NewPoint(name, nil, nil, timeNow)
 	}
 
-	// fmt.Println("\t", time.Now(), " : write word_types_rates")
+	fmt.Println("\t", time.Now(), " : write word_types_rates")
 
 	point := makePoint("word_types_rates")
 	for wordtype, count := range m.WordTypeCounts {
@@ -32,7 +31,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 	}
 	writeAPI.WritePoint(context.Background(), point)
 
-	// fmt.Println("\t", time.Now(), " : write data_statuses_rates")
+	fmt.Println("\t", time.Now(), " : write data_statuses_rates")
 
 	for ioChannel, counts := range m.DataStatusCounts {
 		point = makePoint("data_statuses_rates")
@@ -40,7 +39,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddTag("io_group", strconv.Itoa(int(ioChannel.IoGroup)))
 		point.AddTag("tile_id", strconv.Itoa(IoChannelToTileId(int(ioChannel.IoChannel))))
 		point.AddTag("io_channel", strconv.Itoa(int(ioChannel.IoChannel)))
-		
+
 		point.AddField("total", float64(counts.Total)/timeDiff)
 		point.AddField("valid_parity", float64(counts.ValidParity)/timeDiff)
 		point.AddField("invalid_parity", float64(counts.InvalidParity)/timeDiff)
@@ -49,7 +48,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		writeAPI.WritePoint(context.Background(), point)
 	}
 
-	// fmt.Println("\t", time.Now(), " : write config_statuses_rates")
+	fmt.Println("\t", time.Now(), " : write config_statuses_rates")
 
 	for ioChannel, counts := range m.ConfigStatusCounts {
 		point = makePoint("config_statuses_rates")
@@ -57,7 +56,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddTag("io_group", strconv.Itoa(int(ioChannel.IoGroup)))
 		point.AddTag("tile_id", strconv.Itoa(IoChannelToTileId(int(ioChannel.IoChannel))))
 		point.AddTag("io_channel", strconv.Itoa(int(ioChannel.IoChannel)))
-		
+
 		point.AddField("total", float64(counts.Total)/timeDiff)
 		point.AddField("invalid_parity", float64(counts.InvalidParity)/timeDiff)
 		point.AddField("downstream_read", float64(counts.DownstreamRead)/timeDiff)
@@ -67,7 +66,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		writeAPI.WritePoint(context.Background(), point)
 	}
 
-	// fmt.Println("\t", time.Now(), " : write data_statuses_rates_per_chip")
+	fmt.Println("\t", time.Now(), " : write data_statuses_rates_per_chip")
 
 	for chip, counts := range m.DataStatusCountsPerChip {
 		point = makePoint("data_statuses_rates_per_chip")
@@ -76,7 +75,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddTag("tile_id", strconv.Itoa(IoChannelToTileId(int(chip.IoChannel))))
 		point.AddTag("io_channel", strconv.Itoa(int(chip.IoChannel)))
 		point.AddTag("chip", strconv.Itoa(int(chip.ChipID)))
-		
+
 		point.AddField("total", float64(counts.Total)/timeDiff)
 		point.AddField("valid_parity", float64(counts.ValidParity)/timeDiff)
 		point.AddField("invalid_parity", float64(counts.InvalidParity)/timeDiff)
@@ -85,7 +84,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		writeAPI.WritePoint(context.Background(), point)
 	}
 
-	// fmt.Println("\t", time.Now(), " : write config_statuses_rates_per_chip")
+	fmt.Println("\t", time.Now(), " : write config_statuses_rates_per_chip")
 
 	for chip, counts := range m.ConfigStatusCountsPerChip {
 		point = makePoint("config_statuses_rates_per_chip")
@@ -94,7 +93,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddTag("tile_id", strconv.Itoa(IoChannelToTileId(int(chip.IoChannel))))
 		point.AddTag("io_channel", strconv.Itoa(int(chip.IoChannel)))
 		point.AddTag("chip", strconv.Itoa(int(chip.ChipID)))
-		
+
 		point.AddField("total", float64(counts.Total)/timeDiff)
 		point.AddField("invalid_parity", float64(counts.InvalidParity)/timeDiff)
 		point.AddField("downstream_read", float64(counts.DownstreamRead)/timeDiff)
@@ -104,7 +103,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		writeAPI.WritePoint(context.Background(), point)
 	}
 
-	// fmt.Println("\t", time.Now(), " : write local_fifo_statuses")
+	fmt.Println("\t", time.Now(), " : write local_fifo_statuses")
 
 	for channel, counts := range m.FifoFlagCounts {
 		total := float64(counts.LocalFifoLessHalfFull + counts.LocalFifoMoreHalfFull + counts.LocalFifoFull)
@@ -116,7 +115,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddTag("io_group", strconv.Itoa(int(channel.IoGroup)))
 		point.AddTag("io_channel", strconv.Itoa(int(channel.IoChannel)))
 		point.AddTag("tile_id", strconv.Itoa(IoChannelToTileId(int(channel.IoChannel))))
-		
+
 		point.AddTag("chip", strconv.Itoa(int(channel.ChipID)))
 		point.AddTag("channel", strconv.Itoa(int(channel.ChannelID)))
 
@@ -127,7 +126,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		writeAPI.WritePoint(context.Background(), point)
 	}
 
-	// fmt.Println("\t", time.Now(), " : write shared_fifo_statuses")
+	fmt.Println("\t", time.Now(), " : write shared_fifo_statuses")
 
 	for channel, counts := range m.FifoFlagCounts {
 		total := float64(counts.SharedFifoLessHalfFull + counts.SharedFifoMoreHalfFull + counts.SharedFifoFull)
@@ -149,16 +148,15 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		writeAPI.WritePoint(context.Background(), point)
 	}
 
-
 }
 
 func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time, timeDiff float64) {
 
-	makePoint := func (name string) *write.Point {
+	makePoint := func(name string) *write.Point {
 		return influxdb2.NewPoint(name, nil, nil, timeNow)
 	}
 
-	// fmt.Println("\t", time.Now(), " : write packet_adc_total")
+	fmt.Println("\t", time.Now(), " : write packet_adc_total")
 
 	point := makePoint("packet_adc_total")
 	point.AddField("adc_mean", m10s.ADCMeanTotal)
@@ -166,7 +164,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow tim
 	point.AddField("n_packets", m10s.NPacketsTotal)
 	writeAPI.WritePoint(context.Background(), point)
 
-	// fmt.Println("\t", time.Now(), " : write packet_adc_per_channel")
+	fmt.Println("\t", time.Now(), " : write packet_adc_per_channel")
 
 	for channel, adc := range m10s.ADCMeanPerChannel {
 		point = makePoint("packet_adc_per_channel")
@@ -184,7 +182,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow tim
 		writeAPI.WritePoint(context.Background(), point)
 	}
 
-	// fmt.Println("\t", time.Now(), " : write packet_adc_per_chip")
+	fmt.Println("\t", time.Now(), " : write packet_adc_per_chip")
 
 	for chip, adc := range m10s.ADCMeanPerChip {
 		point = makePoint("packet_adc_per_chip")
@@ -201,7 +199,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow tim
 		writeAPI.WritePoint(context.Background(), point)
 	}
 
-	// fmt.Println("\t", time.Now(), " : write data_statuses_rates_per_channel")
+	fmt.Println("\t", time.Now(), " : write data_statuses_rates_per_channel")
 
 	for channel, counts := range m10s.DataStatusCountsPerChannel {
 		point = makePoint("data_statuses_rates_per_channel")
@@ -221,7 +219,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow tim
 		writeAPI.WritePoint(context.Background(), point)
 	}
 
-	// fmt.Println("\t", time.Now(), " : write config_statuses_rates_per_channel")
+	fmt.Println("\t", time.Now(), " : write config_statuses_rates_per_channel")
 
 	for channel, counts := range m10s.ConfigStatusCountsPerChannel {
 		point = makePoint("config_statuses_rates_per_channel")
@@ -242,12 +240,11 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow tim
 		writeAPI.WritePoint(context.Background(), point)
 	}
 
-
 }
 
 func (sm *SyncMonitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time) {
 
-	makePoint := func (name string) *write.Point {
+	makePoint := func(name string) *write.Point {
 		return influxdb2.NewPoint(name, nil, nil, timeNow)
 	}
 
@@ -256,13 +253,13 @@ func (sm *SyncMonitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time
 
 		point.AddTag("io_group", strconv.Itoa(int(sm.IoGroup[ind])))
 
-		if sm.Type[ind] == SyncTypeSync { 
-			point.AddField("sync", (float64(t) - 1e7) * 0.1) 
+		if sm.Type[ind] == SyncTypeSync {
+			point.AddField("sync", (float64(t)-1e7)*0.1)
 		}
-		if sm.Type[ind] == SyncTypeHeartbeat { 
+		if sm.Type[ind] == SyncTypeHeartbeat {
 			point.AddField("heartbeat", float64(t))
 		}
-		if sm.Type[ind] == SyncTypeClkSource { 
+		if sm.Type[ind] == SyncTypeClkSource {
 			point.AddField("clk_source", float64(t))
 		}
 		writeAPI.WritePoint(context.Background(), point)
@@ -271,7 +268,7 @@ func (sm *SyncMonitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time
 
 func (tm *TrigMonitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time) {
 
-	makePoint := func (name string) *write.Point {
+	makePoint := func(name string) *write.Point {
 		return influxdb2.NewPoint(name, nil, nil, timeNow)
 	}
 
@@ -284,15 +281,4 @@ func (tm *TrigMonitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time
 
 		writeAPI.WritePoint(context.Background(), point)
 	}
-}
-
-func getWriteAPI(url, org, bucket string) api.WriteAPIBlocking {
-	token := os.Getenv("INFLUXDB_TOKEN")
-	if token == "" {
-		fmt.Fprintf(os.Stderr,
-			"Please set the INFLUXDB_TOKEN environment variable\n")
-		os.Exit(1)
-	}
-	client := influxdb2.NewClient(url, token)
-	return client.WriteAPIBlocking(org, bucket)
 }

--- a/influx.go
+++ b/influx.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -15,7 +14,7 @@ func IoChannelToTileId(ioChannel int) int {
 	return (ioChannel-1)/4 + 1
 }
 
-func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time, timeDiff float64) {
+func (m *Monitor) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, timeDiff float64) {
 
 	fmt.Println("\t", time.Now(), " : start writing to influx")
 
@@ -29,7 +28,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 	for wordtype, count := range m.WordTypeCounts {
 		point.AddField(wordtype.String(), float64(count)/timeDiff)
 	}
-	writeAPI.WritePoint(context.Background(), point)
+	writeAPI.WritePoint(point)
 
 	fmt.Println("\t", time.Now(), " : write data_statuses_rates")
 
@@ -45,7 +44,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddField("invalid_parity", float64(counts.InvalidParity)/timeDiff)
 		point.AddField("downstream", float64(counts.Downstream)/timeDiff)
 		point.AddField("upstream", float64(counts.Upstream)/timeDiff)
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
 
 	fmt.Println("\t", time.Now(), " : write config_statuses_rates")
@@ -63,7 +62,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddField("downstream_write", float64(counts.DownstreamWrite)/timeDiff)
 		point.AddField("upstream_read", float64(counts.UpstreamRead)/timeDiff)
 		point.AddField("upstream_write", float64(counts.UpstreamWrite)/timeDiff)
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
 
 	fmt.Println("\t", time.Now(), " : write data_statuses_rates_per_chip")
@@ -81,7 +80,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddField("invalid_parity", float64(counts.InvalidParity)/timeDiff)
 		point.AddField("downstream", float64(counts.Downstream)/timeDiff)
 		point.AddField("upstream", float64(counts.Upstream)/timeDiff)
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
 
 	fmt.Println("\t", time.Now(), " : write config_statuses_rates_per_chip")
@@ -100,7 +99,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddField("downstream_write", float64(counts.DownstreamWrite)/timeDiff)
 		point.AddField("upstream_read", float64(counts.UpstreamRead)/timeDiff)
 		point.AddField("upstream_write", float64(counts.UpstreamWrite)/timeDiff)
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
 
 	fmt.Println("\t", time.Now(), " : write local_fifo_statuses")
@@ -123,7 +122,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddField("more_half_full", float64(counts.LocalFifoMoreHalfFull)/total)
 		point.AddField("full", float64(counts.LocalFifoFull)/total)
 
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
 
 	fmt.Println("\t", time.Now(), " : write shared_fifo_statuses")
@@ -145,12 +144,14 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time
 		point.AddField("more_half_full", float64(counts.SharedFifoMoreHalfFull)/total)
 		point.AddField("full", float64(counts.SharedFifoFull)/total)
 
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
+
+	writeAPI.Flush()
 
 }
 
-func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time, timeDiff float64) {
+func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, timeDiff float64) {
 
 	makePoint := func(name string) *write.Point {
 		return influxdb2.NewPoint(name, nil, nil, timeNow)
@@ -162,7 +163,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow tim
 	point.AddField("adc_mean", m10s.ADCMeanTotal)
 	point.AddField("adc_rms", m10s.ADCRMSTotal)
 	point.AddField("n_packets", m10s.NPacketsTotal)
-	writeAPI.WritePoint(context.Background(), point)
+	writeAPI.WritePoint(point)
 
 	fmt.Println("\t", time.Now(), " : write packet_adc_per_channel")
 
@@ -179,7 +180,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow tim
 		point.AddField("adc_rms", m10s.ADCRMSPerChannel[channel])
 		point.AddField("n_packets", m10s.NPacketsPerChannel[channel])
 
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
 
 	fmt.Println("\t", time.Now(), " : write packet_adc_per_chip")
@@ -196,7 +197,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow tim
 		point.AddField("adc_rms", m10s.ADCRMSPerChip[chip])
 		point.AddField("n_packets", m10s.NPacketsPerChip[chip])
 
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
 
 	fmt.Println("\t", time.Now(), " : write data_statuses_rates_per_channel")
@@ -216,7 +217,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow tim
 		point.AddField("downstream", float64(counts.Downstream)/timeDiff)
 		point.AddField("upstream", float64(counts.Upstream)/timeDiff)
 
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
 
 	fmt.Println("\t", time.Now(), " : write config_statuses_rates_per_channel")
@@ -237,12 +238,14 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow tim
 		point.AddField("upstream_read", float64(counts.UpstreamRead)/timeDiff)
 		point.AddField("upstream_write", float64(counts.UpstreamWrite)/timeDiff)
 
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
+
+	writeAPI.Flush()
 
 }
 
-func (sm *SyncMonitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time) {
+func (sm *SyncMonitor) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time) {
 
 	makePoint := func(name string) *write.Point {
 		return influxdb2.NewPoint(name, nil, nil, timeNow)
@@ -262,11 +265,13 @@ func (sm *SyncMonitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time
 		if sm.Type[ind] == SyncTypeClkSource {
 			point.AddField("clk_source", float64(t))
 		}
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
+
+	writeAPI.Flush()
 }
 
-func (tm *TrigMonitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time.Time) {
+func (tm *TrigMonitor) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time) {
 
 	makePoint := func(name string) *write.Point {
 		return influxdb2.NewPoint(name, nil, nil, timeNow)
@@ -279,6 +284,8 @@ func (tm *TrigMonitor) WriteToInflux(writeAPI api.WriteAPIBlocking, timeNow time
 
 		point.AddField("trig", float64(t))
 
-		writeAPI.WritePoint(context.Background(), point)
+		writeAPI.WritePoint(point)
 	}
+
+	writeAPI.Flush()
 }

--- a/influx.go
+++ b/influx.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -16,13 +15,13 @@ func IoChannelToTileId(ioChannel int) int {
 
 func (m *Monitor) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, timeDiff float64) {
 
-	fmt.Println("\t", time.Now(), " : start writing to influx")
+	// fmt.Println("\t", time.Now(), " : start writing to influx")
 
 	makePoint := func(name string) *write.Point {
 		return influxdb2.NewPoint(name, nil, nil, timeNow)
 	}
 
-	fmt.Println("\t", time.Now(), " : write word_types_rates")
+	// fmt.Println("\t", time.Now(), " : write word_types_rates")
 
 	point := makePoint("word_types_rates")
 	for wordtype, count := range m.WordTypeCounts {
@@ -30,7 +29,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, timeDi
 	}
 	writeAPI.WritePoint(point)
 
-	fmt.Println("\t", time.Now(), " : write data_statuses_rates")
+	// fmt.Println("\t", time.Now(), " : write data_statuses_rates")
 
 	for ioChannel, counts := range m.DataStatusCounts {
 		point = makePoint("data_statuses_rates")
@@ -47,7 +46,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, timeDi
 		writeAPI.WritePoint(point)
 	}
 
-	fmt.Println("\t", time.Now(), " : write config_statuses_rates")
+	// fmt.Println("\t", time.Now(), " : write config_statuses_rates")
 
 	for ioChannel, counts := range m.ConfigStatusCounts {
 		point = makePoint("config_statuses_rates")
@@ -65,7 +64,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, timeDi
 		writeAPI.WritePoint(point)
 	}
 
-	fmt.Println("\t", time.Now(), " : write data_statuses_rates_per_chip")
+	// fmt.Println("\t", time.Now(), " : write data_statuses_rates_per_chip")
 
 	for chip, counts := range m.DataStatusCountsPerChip {
 		point = makePoint("data_statuses_rates_per_chip")
@@ -83,7 +82,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, timeDi
 		writeAPI.WritePoint(point)
 	}
 
-	fmt.Println("\t", time.Now(), " : write config_statuses_rates_per_chip")
+	// fmt.Println("\t", time.Now(), " : write config_statuses_rates_per_chip")
 
 	for chip, counts := range m.ConfigStatusCountsPerChip {
 		point = makePoint("config_statuses_rates_per_chip")
@@ -102,7 +101,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, timeDi
 		writeAPI.WritePoint(point)
 	}
 
-	fmt.Println("\t", time.Now(), " : write local_fifo_statuses")
+	// fmt.Println("\t", time.Now(), " : write local_fifo_statuses")
 
 	for channel, counts := range m.FifoFlagCounts {
 		total := float64(counts.LocalFifoLessHalfFull + counts.LocalFifoMoreHalfFull + counts.LocalFifoFull)
@@ -125,7 +124,7 @@ func (m *Monitor) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, timeDi
 		writeAPI.WritePoint(point)
 	}
 
-	fmt.Println("\t", time.Now(), " : write shared_fifo_statuses")
+	// fmt.Println("\t", time.Now(), " : write shared_fifo_statuses")
 
 	for channel, counts := range m.FifoFlagCounts {
 		total := float64(counts.SharedFifoLessHalfFull + counts.SharedFifoMoreHalfFull + counts.SharedFifoFull)
@@ -157,7 +156,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, 
 		return influxdb2.NewPoint(name, nil, nil, timeNow)
 	}
 
-	fmt.Println("\t", time.Now(), " : write packet_adc_total")
+	// fmt.Println("\t", time.Now(), " : write packet_adc_total")
 
 	point := makePoint("packet_adc_total")
 	point.AddField("adc_mean", m10s.ADCMeanTotal)
@@ -165,7 +164,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, 
 	point.AddField("n_packets", m10s.NPacketsTotal)
 	writeAPI.WritePoint(point)
 
-	fmt.Println("\t", time.Now(), " : write packet_adc_per_channel")
+	// fmt.Println("\t", time.Now(), " : write packet_adc_per_channel")
 
 	for channel, adc := range m10s.ADCMeanPerChannel {
 		point = makePoint("packet_adc_per_channel")
@@ -183,7 +182,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, 
 		writeAPI.WritePoint(point)
 	}
 
-	fmt.Println("\t", time.Now(), " : write packet_adc_per_chip")
+	// fmt.Println("\t", time.Now(), " : write packet_adc_per_chip")
 
 	for chip, adc := range m10s.ADCMeanPerChip {
 		point = makePoint("packet_adc_per_chip")
@@ -200,7 +199,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, 
 		writeAPI.WritePoint(point)
 	}
 
-	fmt.Println("\t", time.Now(), " : write data_statuses_rates_per_channel")
+	// fmt.Println("\t", time.Now(), " : write data_statuses_rates_per_channel")
 
 	for channel, counts := range m10s.DataStatusCountsPerChannel {
 		point = makePoint("data_statuses_rates_per_channel")
@@ -220,7 +219,7 @@ func (m10s *Monitor10s) WriteToInflux(writeAPI api.WriteAPI, timeNow time.Time, 
 		writeAPI.WritePoint(point)
 	}
 
-	fmt.Println("\t", time.Now(), " : write config_statuses_rates_per_channel")
+	// fmt.Println("\t", time.Now(), " : write config_statuses_rates_per_channel")
 
 	for channel, counts := range m10s.ConfigStatusCountsPerChannel {
 		point = makePoint("config_statuses_rates_per_channel")

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ var cmd = cobra.Command{
 	Run:   run,
 }
 
-func runSingle(singlePacmanURL string, ioGroup uint8, geometry Geometry, PlotNorms Norms, client influxdb2.Client, wg *sync.WaitGroup) {
+func runSingle(singlePacmanURL string, ioGroup uint8, geometry Geometry, plotNorms Norms, client influxdb2.Client, wg *sync.WaitGroup) {
 
 	defer wg.Done()
 
@@ -103,21 +103,21 @@ func runSingle(singlePacmanURL string, ioGroup uint8, geometry Geometry, PlotNor
 
 		if time.Since(last).Seconds() > 1 {
 			now = time.Now()
-			monitor.WriteToInflux(writeAPI, now, now.Sub(last).Seconds())
+			monitor.WriteToInflux(writeAPI, time.Unix(msgTime, 0), now.Sub(last).Seconds())
 			monitor = NewMonitor() // Reset monitor
 			last = now
 		}
 
 		if time.Since(last10s).Seconds() > 10 {
 			now10s = time.Now()
-			monitor10s.WriteToInflux(writeAPI, now10s, now10s.Sub(last10s).Seconds())
+			monitor10s.WriteToInflux(writeAPI, time.Unix(msgTime, 0), now10s.Sub(last10s).Seconds())
 			monitor10s = NewMonitor10s() // Reset monitor
 			last10s = now10s
 		}
 
 		if time.Since(lastPlots).Seconds() > 30 {
 			nowPlots = time.Now()
-			monitorPlots.PlotMetrics(geometry, ioGroup, PlotNorms, nowPlots.Sub(lastPlots).Seconds())
+			monitorPlots.PlotMetrics(geometry, ioGroup, plotNorms, nowPlots.Sub(lastPlots).Seconds())
 			monitorPlots = NewMonitorPlots() // Reset monitor
 			lastPlots = nowPlots
 		}
@@ -140,7 +140,7 @@ func run(cmd *cobra.Command, args []string) {
 
 	content, err := os.ReadFile(PacmanIoJson)
 	if err == nil {
-		fmt.Println("Reading IO config from JSON file...")
+		fmt.Println("Reading IO config from JSON file: ", PacmanIoJson)
 		var config IoConfig
 
 		err = json.Unmarshal([]byte(content), &config)
@@ -151,13 +151,13 @@ func run(cmd *cobra.Command, args []string) {
 
 		PacmanURL = nil
 		PacmanIog = nil
+
+		fmt.Println("Found the following PACMANs vs. IO groups: ")
 		for _, iog := range config.IoGroupPacmanURL {
 			PacmanURL = append(PacmanURL, fmt.Sprintf("tcp://%s:5556", iog[1].(string)))
 			PacmanIog = append(PacmanIog, strconv.Itoa(int(iog[0].(float64))))
+			fmt.Println("\tURL: ", PacmanURL[len(PacmanURL)-1], " - io_group = ", PacmanIog[len(PacmanIog)-1])
 		}
-
-		fmt.Println("Read URLs: ", PacmanURL)
-		fmt.Println("Corresponding to IO groups: ", PacmanIog)
 
 	} else {
 		fmt.Println("Error when opening configuration file: ", err)

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func runSingle(singlePacmanURL string, ioGroup uint8, geometry Geometry, PlotNor
 	socket.SetSubscribe("")
 	socket.Connect(singlePacmanURL)
 
-	writeAPI := client.WriteAPIBlocking(InfluxOrg, InfluxBucket)
+	writeAPI := client.WriteAPI(InfluxOrg, InfluxBucket)
 	now := time.Now()
 	last := time.Now()
 	now10s := time.Now()


### PR DESCRIPTION
Imporved performance by:
- Switching to non-blocking influxdb write client for batching and asynchronous writing based on the example [here](https://github.com/influxdata/influxdb-client-go?tab=readme-ov-file#non-blocking-write-client) (this has the biggest impact on the performance)
- Using millisecond precision for timestamps based on the suggestions [here](https://docs.influxdata.com/influxdb/v2/write-data/best-practices/optimize-writes/) (only a small impact)


Other changes:
- Set one common client for all the writing processes based on the suggestion [here](https://github.com/influxdata/influxdb-client-go?tab=readme-ov-file#concurrency)
- Use the PACMAN message timestamps for the timestamps in influxdb 